### PR TITLE
feat: upgraded to tfe-drift v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v0.5.0] - 2024-10-07
+
+### Changed
+
+- Use tfe-drift v0.5.0
+
 ## [v0.4.0] - 2022-11-28
 
 ### Changed
@@ -33,7 +39,8 @@
 
 - Use tfe-drift v0.1.0
 
-[unreleased]: https://github.com/slok/tfe-drift-action/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/slok/tfe-drift-action/compare/v0.5.0...HEAD
+[v0.4.0]: https://github.com/slok/tfe-drift-action/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/slok/tfe-drift-action/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/slok/tfe-drift-action/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/slok/tfe-drift-action/compare/v0.1.0...v0.2.0

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Install tfe-drift
       shell: bash
       env:
-        TFE_DRIFT_VERSION: v0.4.0
+        TFE_DRIFT_VERSION: v0.5.0
       run: curl -L https://github.com/slok/tfe-drift/releases/download/${TFE_DRIFT_VERSION}/tfe-drift-linux-amd64 > /tmp/tfe-drift && chmod a+x /tmp/tfe-drift
     - id: tfe-drift-run
       name: Run drift detection


### PR DESCRIPTION
This should update the action to use v0.5.0 version of tfe-drift 

resolves #4 